### PR TITLE
Adding Read more... links for long posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,6 +36,7 @@ permalink: /:title
 
 # Allow for manually setting the cut-off for the excerpt:
 excerpt_separator: <!--more-->
+read_more_text: "Read more…"
 
 # Set to true if you don't want to see the author sidebar on posts:
 hide_author: true

--- a/_includes/entry.html
+++ b/_includes/entry.html
@@ -1,0 +1,38 @@
+{% if entry.id %}
+  {% assign title = entry.title | markdownify | strip_html %}
+{% else %}
+  {% assign title = entry.title %}
+{% endif %}
+
+<article class="entry h-entry">
+  <header class="entry-header">
+    <h3 class="entry-title p-name">
+      {% if entry.link %}
+        <a class="u-bookmark-of" href="{{ entry.link }}">{{ title }}</a> <a href="{{ entry.url | relative_url }}" rel="bookmark"><span class="link-arrow">&rarr;</span></a>
+      {% else %}
+        <a href="{{ entry.url | relative_url }}" rel="bookmark">{{ title }}</a>
+      {% endif %}
+    </h3>
+    {% if entry.image.thumbnail %}
+      {% assign entry_image = entry.image.thumbnail %}
+      {% unless entry_image contains '://' %}
+        {% assign entry_image = entry_image | relative_url %}
+      {% endunless %}
+      {% assign entry_image = entry_image | escape %}
+      <img class="entry-image u-photo" src="{{ entry_image }}" alt="">
+    {% endif %}
+  </header>
+  {% unless page.show_excerpts == false %}
+    <div class="entry-excerpt p-summary">
+      {% if entry.excerpt %}
+        {{ entry.excerpt | markdownify }}
+      {% endif %}
+    </div>
+  {% endunless %}
+  {% if site.read_time or entry.date and page.layout != 'collection' %}
+    <footer class="entry-meta">
+      {% if site.read_time %}{% include read-time.html %}{% endif %}
+      {% if entry.date %}{% include entry-date.html %}{% endif %}
+    </footer>
+  {% endif %}
+</article>

--- a/_includes/entry.html
+++ b/_includes/entry.html
@@ -3,6 +3,8 @@
 {% else %}
   {% assign title = entry.title %}
 {% endif %}
+{% assign content_size = entry.content | size %}
+{% assign excerpt_size = entry.excerpt | size %}
 
 <article class="entry h-entry">
   <header class="entry-header">
@@ -27,6 +29,14 @@
       {% if entry.excerpt %}
         {{ entry.excerpt | markdownify }}
       {% endif %}
+
+      {% comment %}
+        Add a Read More link:
+      {% endcomment %}
+      {% if content_size > excerpt_size %}
+        <p><a href="{{ entry.url | relative_url }}">{{ site.read_more_text }}</a></p>
+      {% endif %}
+
     </div>
   {% endunless %}
   {% if site.read_time or entry.date and page.layout != 'collection' %}


### PR DESCRIPTION
This PR modifies the template for rendering entries (e.g. the summaries shown on the home page) to include a Read more... link if the entire post is not rendered.

A new site-level tag, `read_more_text`, is added to `_config.yml` to allow for customizing the text of the link. In the future one could add i18n support by setting this tag dynamically, but for now it is set using static English text.